### PR TITLE
Use Kramdown instead of Maruku to process markdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+# The default markdown processor "Maruku" is very particular about strict markdown.
+# Tell Jekyll to use Kramdown instead to allow the site to build.
+markdown: kramdown


### PR DESCRIPTION
The default markdown processor "Maruku" is very particular about strict markdown.
Tell Jekyll to use Kramdown instead to allow the site to build.

PING: @leahbannon 

:fire: :rotating_light: :fire_engine: :rocket: :smile: 
